### PR TITLE
Use macro sizedbytes to remove redundant decl of byte string length

### DIFF
--- a/demos/hello rust/Cargo.toml
+++ b/demos/hello rust/Cargo.toml
@@ -7,6 +7,8 @@ authors = ["Steve Klabnik <steve@steveklabnik.com>"]
 crate-type = ["staticlib"]
 
 [dependencies]
+bytestool = "0.2.0"
+sizedbytes = "0.1.0"
 
 [profile.release]
 panic = "abort"

--- a/demos/hello rust/src/lib.rs
+++ b/demos/hello rust/src/lib.rs
@@ -1,15 +1,21 @@
 #![feature(lang_items)]
 #![no_std]
 
+#![feature(plugin)]
+#![plugin(bytestool)]
+#[macro_use(sized_bytes)]
+
+extern crate sizedbytes;
+use sizedbytes::SizedBytes;
+
 #[no_mangle]
 pub extern fn kmain() -> ! {
-    let char_bytes = b"Hello World!";
+    const MESG : SizedBytes = sized_bytes!(b"Hello World");
 
     let color_byte = 0x1f;
 
-
-    let mut message = [color_byte; 24];
-    for (i, char_byte) in char_bytes.into_iter().enumerate() {
+    let mut message = [color_byte; MESG.size * 2 ];
+    for (i, char_byte) in MESG.bytes.into_iter().enumerate() {
       message[i * 2] = *char_byte;
     }
 


### PR DESCRIPTION
Hi, I developed a macro so that redundant length of byte array can be removed. As the makefile fails to build the demo for me at all, I can not verify. Please could you check if the patch works fine for you?
